### PR TITLE
fix(notifications): do not crash when asking for notification permission

### DIFF
--- a/hooks/use-push-notifications.ts
+++ b/hooks/use-push-notifications.ts
@@ -22,7 +22,7 @@ function isNotificationSupported(): boolean {
 }
 
 function getNotificationPermission(): NotificationPermission {
-  if (!isNotificationSupported()) return 'default';
+  if (!isNotificationSupported()) return 'denied';
   return Notification.permission;
 }
 

--- a/hooks/use-push-notifications.ts
+++ b/hooks/use-push-notifications.ts
@@ -30,7 +30,7 @@ async function requestNotificationPermission(): Promise<NotificationPermission> 
   if (!isNotificationSupported()) return 'denied';
 
   // For iOS Safari, we need to request permission in response to user interaction
-  if ('requestPermission' in Notification) {
+  if (typeof Notification.requestPermission === 'function') {
     return await Notification.requestPermission();
   }
 


### PR DESCRIPTION
This pull request enhances the `usePushNotifications` hook to improve notification permission handling and ensure compatibility with different environments. The main changes include adding utility functions to manage notification permissions and updating the hook logic to use these new functions.

### Notification Permission Handling:

* Added utility functions `isNotificationSupported`, `getNotificationPermission`, and `requestNotificationPermission` to encapsulate notification-related checks and requests. These functions ensure consistent handling of notification permissions and account for unsupported environments. (`hooks/use-push-notifications.ts`, [hooks/use-push-notifications.tsR20-R39](diffhunk://#diff-26c00bd885636bc58b8fdf45ad6d6d4d77473a60102f2615863fb49879c650f6R20-R39))

* Updated the `usePushNotifications` hook to use the new `getNotificationPermission` and `requestNotificationPermission` functions instead of directly accessing `Notification.permission` and `Notification.requestPermission`. This improves code readability and ensures proper fallback behavior. (`hooks/use-push-notifications.ts`, [[1]](diffhunk://#diff-26c00bd885636bc58b8fdf45ad6d6d4d77473a60102f2615863fb49879c650f6L101-R125) [[2]](diffhunk://#diff-26c00bd885636bc58b8fdf45ad6d6d4d77473a60102f2615863fb49879c650f6L145-R165)

### Compatibility Enhancements:

* Modified the `usePushNotifications` hook to include a check for `isNotificationSupported` when determining if push notifications are supported. This prevents errors in environments where notifications are not available. (`hooks/use-push-notifications.ts`, [hooks/use-push-notifications.tsL83-R103](diffhunk://#diff-26c00bd885636bc58b8fdf45ad6d6d4d77473a60102f2615863fb49879c650f6L83-R103))