### PR TITLE
feat: hide mobile navbar when typing on mobile

### DIFF
--- a/components/mobile-platform-navbar.tsx
+++ b/components/mobile-platform-navbar.tsx
@@ -4,8 +4,12 @@ import { LoadingLink } from "@/components/ui/loading-link";
 import { usePathname } from "next/navigation";
 import { useMenuItems } from "@/hooks/use-menu-items";
 import { cn } from "@/lib/utils";
+import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
 
 export default function MobilePlatformNavbar() {
+  const keyboardOpen = useKeyboardOpen(100);
+  if (keyboardOpen) return null;
+
   const pathname = usePathname();
   const items = useMenuItems();
   return (

--- a/hooks/use-keyboard-open.ts
+++ b/hooks/use-keyboard-open.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useKeyboardOpen(threshold = 100) {
+  const [keyboardOpen, setKeyboardOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+
+    const initialHeight = window.visualViewport.height;
+
+    const onResize = () => {
+      const heightDiff = initialHeight - window.visualViewport.height;
+      setKeyboardOpen(heightDiff > threshold);
+    };
+
+    window.visualViewport.addEventListener("resize", onResize);
+
+    return () => window.visualViewport.removeEventListener("resize", onResize);
+  }, [threshold]);
+
+  return keyboardOpen;
+}


### PR DESCRIPTION
This pull request introduces a new hook, `useKeyboardOpen`, to detect when the virtual keyboard is open based on viewport height changes. It also integrates this hook into the `MobilePlatformNavbar` component to hide the navbar when the keyboard is open.

Enhancements to keyboard detection:

* [`hooks/use-keyboard-open.ts`](diffhunk://#diff-68bc7faace5d7bf612939d065ad1ff5003a56166d155a2b71103148a62dc1ad5R1-R22): Added the `useKeyboardOpen` hook, which monitors viewport height changes to determine if the virtual keyboard is open. It uses a threshold value to decide when to trigger the `keyboardOpen` state.

Integration into the mobile navbar:

* [`components/mobile-platform-navbar.tsx`](diffhunk://#diff-4b3ece3cf9aca9e85f0dfaf7898940d7640e21126884e0abde2b386bed03bd53R7-R12): Imported and utilized the `useKeyboardOpen` hook to conditionally render the `MobilePlatformNavbar`. The navbar is hidden if the keyboard is open.